### PR TITLE
Allow team colorEdits to be disabled from config

### DIFF
--- a/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
+++ b/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
@@ -30,7 +30,7 @@ public class MainConfiguration {
 	private int minPlayersToStart;
 	private int maxPlayersPerTeam;
 	private boolean teamColors;
-	private boolean teamColorVariations;
+	private boolean avoidTeamColorVariations;
 	private boolean changeDisplayNames;
 	private int timeBeforeStartWhenReady;
 	private boolean canSpectateAfterDeath;
@@ -167,7 +167,7 @@ public class MainConfiguration {
 		minPlayersToStart = cfg.getInt("min-players-to-start",0);
 		maxPlayersPerTeam = cfg.getInt("max-players-per-team",2);
 		teamColors = cfg.getBoolean("use-team-colors",true);
-		teamColorVariations = cfg.getBoolean("enable-color-variations",true);
+		avoidTeamColorVariations = cfg.getBoolean("avoid-color-variations",false);
 		changeDisplayNames = cfg.getBoolean("change-display-names",false);
 		timeBeforeStartWhenReady = cfg.getInt("time-to-start-when-ready",15);
 		canSpectateAfterDeath = cfg.getBoolean("can-spectate-after-death",false);
@@ -794,8 +794,8 @@ public class MainConfiguration {
 		return teamColors;
 	}
 
-	public boolean getEnableColorVariations(){
-		return teamColorVariations;
+	public boolean getAvoidTeamColorVariations(){
+		return avoidTeamColorVariations;
 	}
 
 	public boolean getChangeDisplayNames() {

--- a/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
+++ b/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
@@ -30,6 +30,7 @@ public class MainConfiguration {
 	private int minPlayersToStart;
 	private int maxPlayersPerTeam;
 	private boolean teamColors;
+	private boolean teamColorVariations;
 	private boolean changeDisplayNames;
 	private int timeBeforeStartWhenReady;
 	private boolean canSpectateAfterDeath;
@@ -166,6 +167,7 @@ public class MainConfiguration {
 		minPlayersToStart = cfg.getInt("min-players-to-start",0);
 		maxPlayersPerTeam = cfg.getInt("max-players-per-team",2);
 		teamColors = cfg.getBoolean("use-team-colors",true);
+		teamColorVariations = cfg.getBoolean("enable-color-variations",true);
 		changeDisplayNames = cfg.getBoolean("change-display-names",false);
 		timeBeforeStartWhenReady = cfg.getInt("time-to-start-when-ready",15);
 		canSpectateAfterDeath = cfg.getBoolean("can-spectate-after-death",false);
@@ -790,6 +792,10 @@ public class MainConfiguration {
 
 	public boolean getUseTeamColors(){
 		return teamColors;
+	}
+
+	public boolean getEnableColorVariations(){
+		return teamColorVariations;
 	}
 
 	public boolean getChangeDisplayNames() {

--- a/src/main/java/com/gmail/val59000mc/players/TeamManager.java
+++ b/src/main/java/com/gmail/val59000mc/players/TeamManager.java
@@ -1,6 +1,7 @@
 package com.gmail.val59000mc.players;
 
 import com.gmail.val59000mc.game.GameManager;
+import com.gmail.val59000mc.configuration.MainConfiguration;
 import org.bukkit.ChatColor;
 
 import java.util.ArrayList;
@@ -9,11 +10,13 @@ import java.util.List;
 public class TeamManager {
 
     private PlayersManager pm;
+    private MainConfiguration cfg;
     private List<String> prefixes;
     private int lastTeamNumber;
 
     public TeamManager(){
         pm = GameManager.getGameManager().getPlayersManager();
+        cfg = GameManager.getGameManager().getConfiguration();
         lastTeamNumber = 0;
         loadPrefixes();
     }
@@ -67,13 +70,15 @@ public class TeamManager {
 
         List<String> colorEdits = new ArrayList<>();
         colorEdits.add("");
-        colorEdits.add("" + ChatColor.BOLD);
-        colorEdits.add("" + ChatColor.ITALIC);
-        colorEdits.add("" + ChatColor.UNDERLINE);
-        colorEdits.add("" + ChatColor.BOLD + "" + ChatColor.ITALIC);
-        colorEdits.add("" + ChatColor.BOLD + "" + ChatColor.UNDERLINE);
-        colorEdits.add("" + ChatColor.ITALIC + "" + ChatColor.UNDERLINE);
-        colorEdits.add("" + ChatColor.ITALIC + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD);
+        if (cfg.getEnableColorVariations()) {
+            colorEdits.add("" + ChatColor.BOLD);
+            colorEdits.add("" + ChatColor.ITALIC);
+            colorEdits.add("" + ChatColor.UNDERLINE);
+            colorEdits.add("" + ChatColor.BOLD + "" + ChatColor.ITALIC);
+            colorEdits.add("" + ChatColor.BOLD + "" + ChatColor.UNDERLINE);
+            colorEdits.add("" + ChatColor.ITALIC + "" + ChatColor.UNDERLINE);
+            colorEdits.add("" + ChatColor.ITALIC + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD);
+        }
 
         for (String colorEdit : colorEdits){
             for (ChatColor color : colors){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,8 +13,8 @@ max-players-per-team: 2
 #If true every team will get a random team color (This color may be changed in the team color selector).
 use-team-colors: true
 
-#If true multiple teams will be able to select the same color, differentiated by bold/italics/underlines
-enable-color-variations: true
+#If true teams will only be able to select the same colors if all other colors have been exhausted. Players that have a duplicate color when another color is freed will be shifted to that color.
+avoid-color-variations: false
 
 # If true the display name of players will change to the color of their team (The display name shows in chat and in messages of other plugins that use display name).
 change-display-names: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,9 @@ max-players-per-team: 2
 #If true every team will get a random team color (This color may be changed in the team color selector).
 use-team-colors: true
 
+#If true multiple teams will be able to select the same color, differentiated by bold/italics/underlines
+enable-color-variations: true
+
 # If true the display name of players will change to the color of their team (The display name shows in chat and in messages of other plugins that use display name).
 change-display-names: true
 


### PR DESCRIPTION
When playing with less than 10 teams, I generally want to avoid them having the same colour. This PR solves this by adding a config option to disable colorEdits to ensure only one team has a given colour. It is lightly tested, so feel free to test more before merging. 

I have little Java experience so feedback is appreciated.