### PR TITLE
Monsters. Inc. Scenario

### DIFF
--- a/src/main/java/com/gmail/val59000mc/UhcCore.java
+++ b/src/main/java/com/gmail/val59000mc/UhcCore.java
@@ -21,7 +21,7 @@ public class UhcCore extends JavaPlugin{
 	private static final int MIN_VERSION = 8;
 	private static final int MAX_VERSION = 16;
 
-	public static UhcCore pl;
+	private static UhcCore pl;
 	private static int version;
 	private boolean bStats;
 	private Updater updater;

--- a/src/main/java/com/gmail/val59000mc/UhcCore.java
+++ b/src/main/java/com/gmail/val59000mc/UhcCore.java
@@ -21,7 +21,7 @@ public class UhcCore extends JavaPlugin{
 	private static final int MIN_VERSION = 8;
 	private static final int MAX_VERSION = 16;
 
-	private static UhcCore pl;
+	public static UhcCore pl;
 	private static int version;
 	private boolean bStats;
 	private Updater updater;

--- a/src/main/java/com/gmail/val59000mc/languages/Lang.java
+++ b/src/main/java/com/gmail/val59000mc/languages/Lang.java
@@ -173,6 +173,7 @@ public class Lang{
 	public static String SCENARIO_SILENTNIGHT_ERROR;
 	public static String SCENARIO_WEAKESTLINK_KILL;
 	public static String SCENARIO_NOGOINGBACK_ERROR;
+	public static String SCENARIO_MONSTERSINC_ERROR;
 
 	public Lang(){
 		loadLangConfig();
@@ -382,6 +383,7 @@ public class Lang{
 		SCENARIO_SILENTNIGHT_ERROR = getString(lang, "scenarios.silentnight.error", "&4[Silent Night] &cSilent Night is enabled");
 		SCENARIO_WEAKESTLINK_KILL = getString(lang, "scenarios.weakestlink.kill", "&4[Weakest Link] &c%player% has been killed!");
 		SCENARIO_NOGOINGBACK_ERROR = getString(lang, "scenarios.nogoingback.error", "&4[No Going Back] &cYou are stuck in the nether!");
+		SCENARIO_MONSTERSINC_ERROR = getString(lang, "scenarios.monstersinc.error", "&4[Monsters Inc.] &cStop that!");
 
 		if (lang.addedDefaultValues()) {
 			try {

--- a/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
@@ -56,7 +56,8 @@ public enum Scenario{
     FLYHIGH("Fly High", UniversalMaterial.ELYTRA, FlyHighListener.class, 9, "&6Fly High&7:", "&7- Players spawn with a elytra."),
     RANDOMIZEDDROPS("Randomized Drops", UniversalMaterial.EXPERIENCE_BOTTLE, RandomizedDropsListener.class, "&6Randomized Drops&7:", "&7- Every block broken will drop random items." ),
     UPSIDEDOWNCRAFTING("Upside Down Crafting", UniversalMaterial.CRAFTING_TABLE, UpsideDownCraftsListener.class, 13,"&6Upside Down Crafting&7:", "&7- This scenario flips all crafts upside down."),
-    RANDOMIZEDCRAFTS("Randomized Crafts", UniversalMaterial.CRAFTING_TABLE, RandomizedCraftsListener.class, 13,"&6Randomized Crafts&7:", "&7- This scenario randomizes the results of all crafts.");
+    RANDOMIZEDCRAFTS("Randomized Crafts", UniversalMaterial.CRAFTING_TABLE, RandomizedCraftsListener.class, 13,"&6Randomized Crafts&7:", "&7- This scenario randomizes the results of all crafts."),
+    MONSTERSINC("Monsters Inc.", UniversalMaterial.IRON_DOOR, MonstersIncListener.class, "&6Monstersc Inc&7:", "&7- In this scenario all doors are linked as portals.");
 
     private String name;
     private UniversalMaterial material;

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -21,8 +21,8 @@ import org.bukkit.metadata.MetadataValue;
 
 public class MonstersIncListener extends ScenarioListener {
 
-    private int DoorsPlaced;
-    private HashMap<Integer, Location> DoorLocs = new HashMap<>();
+    private int doorsPlaced;
+    private HashMap<Integer, Location> doorLocs;
 
     @EventHandler (ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent e) {
@@ -31,9 +31,9 @@ public class MonstersIncListener extends ScenarioListener {
         Location loc = e.getBlock().getLocation();
 
         if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
-            block.setMetadata("DoorNum", new FixedMetadataValue(UhcCore.getPlugin(UhcCore.class), DoorsPlaced));
-            DoorLocs.put(DoorsPlaced, loc);
-            DoorsPlaced++;
+            block.setMetadata("DoorNum", new FixedMetadataValue(UhcCore.getPlugin(UhcCore.class), doorsPlaced));
+            doorLocs.put(doorsPlaced, loc);
+            doorsPlaced++;
         }
     }
 
@@ -56,11 +56,11 @@ public class MonstersIncListener extends ScenarioListener {
                     List<MetadataValue> values = block.getMetadata("DoorNum");
                     doorClicked = values.get(0).asInt();
                 }
-                if (DoorsPlaced > 1) {
+                if (doorsPlaced > 1) {
                     do {
-                        randomDoor = (int) (Math.random() * DoorLocs.size());
+                        randomDoor = (int) (Math.random() * doorLocs.size());
                     } while (randomDoor == doorClicked);
-                    Location gotoloc = DoorLocs.get(randomDoor);
+                    Location gotoloc = doorLocs.get(randomDoor);
                     player.teleport(gotoloc.clone().add(0.5, 0, 0.5));
                 }
             }

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -1,6 +1,5 @@
 package com.gmail.val59000mc.scenarios.scenariolisteners;
 
-import com.gmail.val59000mc.UhcCore;
 import com.gmail.val59000mc.scenarios.ScenarioListener;
 
 import java.util.List;

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -25,13 +25,20 @@ public class MonstersIncListener extends ScenarioListener {
     private int doorsPlaced;
     private HashMap<Integer, Location> doorLocs;
 
+    public static boolean isDoor(Block b) {
+        if(!b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR")) {
+            return true;
+        }
+        return false;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent e) {
 
         Block block = e.getBlock();
         Location loc = e.getBlock().getLocation();
 
-        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+        if(isDoor(block)) {
             block.setMetadata("DoorNum", new FixedMetadataValue(UhcCore.getPlugin(UhcCore.class), doorsPlaced));
             doorLocs.put(doorsPlaced, loc);
             doorsPlaced++;
@@ -47,7 +54,7 @@ public class MonstersIncListener extends ScenarioListener {
         int doorClicked = -1;
         int randomDoor;
 
-        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+        if(isDoor(block)) {
             Bisected door = (Bisected) block.getBlockData();
             if (action == Action.RIGHT_CLICK_BLOCK) {
                 if (door.getHalf().toString().equals("TOP") || door.getHalf().toString().equals("UPPER")) {
@@ -74,7 +81,7 @@ public class MonstersIncListener extends ScenarioListener {
 
         Block block = e.getBlock();
 
-        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+        if(isDoor(block)) {
             e.getPlayer().sendMessage(Lang.SCENARIO_MONSTERSINC_ERROR);
             e.setCancelled(true);
         }

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -4,7 +4,7 @@ import com.gmail.val59000mc.UhcCore;
 import com.gmail.val59000mc.scenarios.ScenarioListener;
 
 import java.util.List;
-import java.util.HashMap;
+import java.util.ArrayList;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -17,13 +17,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockBreakEvent;
 import com.gmail.val59000mc.languages.Lang;
-import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.metadata.MetadataValue;
 
 public class MonstersIncListener extends ScenarioListener {
 
     private int doorsPlaced;
-    private HashMap<Integer, Location> doorLocs;
+    private List<Location> doorLocs = new ArrayList<Location>();
 
     public static boolean isDoor(Block b) {
         if(!b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR")) {
@@ -39,8 +37,7 @@ public class MonstersIncListener extends ScenarioListener {
         Location loc = e.getBlock().getLocation();
 
         if(isDoor(block)) {
-            block.setMetadata("DoorNum", new FixedMetadataValue(UhcCore.getPlugin(UhcCore.class), doorsPlaced));
-            doorLocs.put(doorsPlaced, loc);
+            doorLocs.add(loc);
             doorsPlaced++;
         }
     }
@@ -51,25 +48,21 @@ public class MonstersIncListener extends ScenarioListener {
         Action action = e.getAction();
         Block block = e.getClickedBlock();
         Player player = e.getPlayer();
-        int doorClicked = -1;
+        Location goToLoc;
         int randomDoor;
 
         if(isDoor(block)) {
             Bisected door = (Bisected) block.getBlockData();
             if (action == Action.RIGHT_CLICK_BLOCK) {
-                if (door.getHalf().toString().equals("TOP") || door.getHalf().toString().equals("UPPER")) {
+                if (door.getHalf().toString().equals("TOP")) {
                     block = block.getRelative(BlockFace.DOWN, 1);
-                }
-                if (block.hasMetadata("DoorNum")) {
-                    List<MetadataValue> values = block.getMetadata("DoorNum");
-                    doorClicked = values.get(0).asInt();
                 }
                 if (doorsPlaced > 1) {
                     do {
                         randomDoor = (int) (Math.random() * doorLocs.size());
-                    } while (randomDoor == doorClicked);
-                    Location gotoloc = doorLocs.get(randomDoor);
-                    player.teleport(gotoloc.clone().add(0.5, 0, 0.5));
+                        goToLoc = doorLocs.get(randomDoor);
+                    } while (goToLoc.equals(block.getLocation()));
+                    player.teleport(goToLoc.clone().add(0.5, 0, 0.5));
                 }
             }
         }

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -19,7 +19,6 @@ import com.gmail.val59000mc.languages.Lang;
 
 public class MonstersIncListener extends ScenarioListener {
 
-    private int doorsPlaced;
     private List<Location> doorLocs;
 
     public MonstersIncListener(){
@@ -27,10 +26,7 @@ public class MonstersIncListener extends ScenarioListener {
     }
 
     public static boolean isDoor(Block b) {
-        if(!b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR")) {
-            return true;
-        }
-        return false;
+        return !b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR");
     }
 
     @EventHandler (ignoreCancelled = true)
@@ -41,7 +37,6 @@ public class MonstersIncListener extends ScenarioListener {
 
         if(isDoor(block)) {
             doorLocs.add(loc);
-            doorsPlaced++;
         }
     }
 
@@ -52,7 +47,6 @@ public class MonstersIncListener extends ScenarioListener {
         Block block = e.getClickedBlock();
         Player player = e.getPlayer();
         Location goToLoc;
-        int randomDoor;
 
         if(isDoor(block)) {
             Bisected door = (Bisected) block.getBlockData();
@@ -60,10 +54,9 @@ public class MonstersIncListener extends ScenarioListener {
                 if (door.getHalf().toString().equals("TOP")) {
                     block = block.getRelative(BlockFace.DOWN, 1);
                 }
-                if (doorsPlaced > 1) {
+                if (doorLocs.size() > 1) {
                     do {
-                        randomDoor = (int) (Math.random() * doorLocs.size());
-                        goToLoc = doorLocs.get(randomDoor);
+                        goToLoc = doorLocs.get((int) (Math.random() * doorLocs.size()));
                     } while (goToLoc.equals(block.getLocation()));
                     player.teleport(goToLoc.clone().add(0.5, 0, 0.5));
                 }

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -1,0 +1,83 @@
+package com.gmail.val59000mc.scenarios.scenariolisteners;
+
+import com.gmail.val59000mc.UhcCore;
+import com.gmail.val59000mc.scenarios.ScenarioListener;
+
+import java.util.List;
+import java.util.HashMap;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
+
+public class MonstersIncListener extends ScenarioListener {
+
+    UhcCore plugin = UhcCore.pl;
+    private int DoorsPlaced;
+    private HashMap<Integer, Location> DoorLocs = new HashMap<>();
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent e) {
+
+        Block block = e.getBlock();
+        Location loc = e.getBlock().getLocation();
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            block.setMetadata("DoorNum", new FixedMetadataValue(plugin, DoorsPlaced));
+            DoorLocs.put(DoorsPlaced, loc);
+            DoorsPlaced++;
+        }
+    }
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockClick(PlayerInteractEvent e) {
+
+        Action action = e.getAction();
+        Block block = e.getClickedBlock();
+        Player player = e.getPlayer();
+        int doorClicked = -1;
+        int randomDoor;
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            Bisected door = (Bisected) block.getBlockData();
+            if (action == Action.RIGHT_CLICK_BLOCK) {
+                if (door.getHalf().toString().equals("TOP") || door.getHalf().toString().equals("UPPER")) {
+                    block = block.getRelative(BlockFace.DOWN, 1);
+                }
+                if (block.hasMetadata("DoorNum")) {
+                    List<MetadataValue> values = block.getMetadata("DoorNum");
+                    doorClicked = values.get(0).asInt();
+                }
+                if (DoorsPlaced > 1) {
+                    do {
+                        randomDoor = (int) (Math.random() * DoorLocs.size());
+                    } while (randomDoor == doorClicked);
+                    Location gotoloc = DoorLocs.get(randomDoor);
+                    player.teleport(gotoloc.clone().add(0.5, 0, 0.5));
+                }
+            }
+        }
+
+    }
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent e) {
+
+        Block block = e.getBlock();
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            e.getPlayer().sendMessage("Stop that!");
+            e.setCancelled(true);
+        }
+
+    }
+}

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockBreakEvent;
+import com.gmail.val59000mc.languages.Lang;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 
@@ -74,7 +75,7 @@ public class MonstersIncListener extends ScenarioListener {
         Block block = e.getBlock();
 
         if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
-            e.getPlayer().sendMessage("Stop that!");
+            e.getPlayer().sendMessage(Lang.SCENARIO_MONSTERSINC_ERROR);
             e.setCancelled(true);
         }
 

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -20,7 +20,11 @@ import com.gmail.val59000mc.languages.Lang;
 public class MonstersIncListener extends ScenarioListener {
 
     private int doorsPlaced;
-    private List<Location> doorLocs = new ArrayList<>();
+    private List<Location> doorLocs;
+
+    public MonstersIncListener(){
+        doorLocs = new ArrayList<Location>();
+    }
 
     public static boolean isDoor(Block b) {
         if(!b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR")) {

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -21,7 +21,7 @@ import com.gmail.val59000mc.languages.Lang;
 public class MonstersIncListener extends ScenarioListener {
 
     private int doorsPlaced;
-    private List<Location> doorLocs = new ArrayList<Location>();
+    private List<Location> doorLocs = new ArrayList<>();
 
     public static boolean isDoor(Block b) {
         if(!b.getType().toString().contains("TRAP") && b.getType().toString().contains("DOOR")) {

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -21,7 +21,6 @@ import org.bukkit.metadata.MetadataValue;
 
 public class MonstersIncListener extends ScenarioListener {
 
-    UhcCore plugin = UhcCore.pl;
     private int DoorsPlaced;
     private HashMap<Integer, Location> DoorLocs = new HashMap<>();
 
@@ -32,7 +31,7 @@ public class MonstersIncListener extends ScenarioListener {
         Location loc = e.getBlock().getLocation();
 
         if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
-            block.setMetadata("DoorNum", new FixedMetadataValue(plugin, DoorsPlaced));
+            block.setMetadata("DoorNum", new FixedMetadataValue(UhcCore.getPlugin(UhcCore.class), DoorsPlaced));
             DoorLocs.put(DoorsPlaced, loc);
             DoorsPlaced++;
         }

--- a/src/main/java/com/gmail/val59000mc/utils/UniversalMaterial.java
+++ b/src/main/java/com/gmail/val59000mc/utils/UniversalMaterial.java
@@ -91,6 +91,7 @@ public enum UniversalMaterial{
     ELYTRA,
     CRAFTING_TABLE("WORKBENCH", "CRAFTING_TABLE"),
     EXPERIENCE_BOTTLE("EXP_BOTTLE", "EXPERIENCE_BOTTLE"),
+    IRON_DOOR,
 
     // Flowers
     POPPY("RED_ROSE", "POPPY", (short) 0),


### PR DESCRIPTION
# Monsters Inc.
Based on the want to play the "Monsters Inc." scenario my friends and I have seen in youtube UHC series, I tried to recreate it for use with UhcCore.

### What this does: 
When two or more doors are placed, they are added to a list. When a door is interacted with (right click), the player is moved to a door that was placed elsewhere in the world.

### What I haven't accounted for:
1. Doors already generated in the world (Villages)
   * This means that doors in villages can still teleport a player, however they will only be teleported to doors made by themselves or another player.
2. Iron doors
   * Iron doors will still send a player to another door, however they stay shut. This could be changed, but I am not sure it needs to. There might be scenarios where a door a player teleports to and can't open is advantageous for another player.

### Considerations
1. Trapdoors can be used as well by removing `!block.getType().toString().contains("TRAP") ` from `MonstersIncListener.java`
2. Adding a cap for doors in the world
3. Adding a cap for doors place by a single player
4. Should players start with doors?
5. Doors are currently unbreakable, ~~but I used a HashMap instead of an ArrayList so that doors could potentially be breakable and removed from the teleport pool in the future.~~
6. Making those ideas as configurable options

### Issues
~~1. The intended behaviour is for a player to end up at a door that isn't the one they're using. This doesn't always happen~~
* This is solved as of 691e7d4


### In closing
Overall, this scenario was fun to create and even more fun to play. I think it could probably be improved in certain areas, but the only big issue I have with it is the description I gave to it in `Scenario.java`, which you can probably improve.