### PR TITLE
Added Functionality to allow a random selection of Deathmatch arenas

### DIFF
--- a/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
+++ b/src/main/java/com/gmail/val59000mc/configuration/MainConfiguration.java
@@ -97,12 +97,13 @@ public class MainConfiguration {
 	// Arena deathmatch
 	private int arenaPasteAtY;
 	private Material arenaTeleportSpotBLock;
-
+	private List<String> arenas;
+	private boolean pickRandomArenaFromList;
+	
 	// Center deathmatch
 	private int deathmatchStartSize;
 	private int deathmatchEndSize;
 	private long deathmatchTimeToShrink;
-
 	private boolean regenHeadDropOnPlayerDeath;
 	private boolean doubleRegenHead;
 	private boolean enableGoldenHeads;
@@ -256,6 +257,7 @@ public class MainConfiguration {
 		timeToShrink = cfg.getLong("border.time-to-shrink",3600);
 		enableTimeLimit = cfg.getBoolean("deathmatch.enable",false);
 		timeLimit = cfg.getLong("deathmatch.delay", timeToShrink);
+		pickRandomArenaFromList = cfg.getBoolean("deathmatch.pick-random-arena-from-list",false);
 		borderIsMoving = cfg.getBoolean("border.moving",false);
 		borderTimeBeforeShrink = cfg.getLong("border.time-before-shrink",0);
 		deathmatchAdvantureMode = cfg.getBoolean("deathmatch.deathmatch-adventure-mode",true);
@@ -386,10 +388,12 @@ public class MainConfiguration {
 
 		// Seed list
 		seeds = cfg.getLongList("world-seeds.list");
-
+		
 		// World list
 		worldsList = cfg.getStringList("world-list.list");
-
+		
+		// Arena List
+		arenas = cfg.getStringList("deathmatch.list");
 		// Fast Mode
 		enableFinalHeal = cfg.getBoolean("fast-mode.final-heal.enable", false);
 		finalHealDelay = cfg.getLong("fast-mode.final-heal.delay", 1200);
@@ -927,9 +931,16 @@ public class MainConfiguration {
 	public boolean getPickRandomWorldFromList() {
 		return pickRandomWorldFromList;
 	}
+	
+	public boolean getPickRandomArenaFromList() {
+		return pickRandomArenaFromList;
+	}
 
 	public List<String> getWorldsList() {
 		return worldsList;
+	}
+	public List<String> getArenaList() {
+		return arenas;
 	}
 
 	public boolean getEnableBungeeSupport() {

--- a/src/main/java/com/gmail/val59000mc/schematics/DeathmatchArena.java
+++ b/src/main/java/com/gmail/val59000mc/schematics/DeathmatchArena.java
@@ -16,10 +16,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 public class DeathmatchArena{
 	private Location loc;
 	private File arenaSchematic;
+	private String mapName;
 	private boolean enable;
 	private List<Location> teleportSpots;
 	private boolean built;
@@ -36,10 +38,20 @@ public class DeathmatchArena{
 	
 	private void checkIfSchematicCanBePasted() {
 		if(GameManager.getGameManager().getConfiguration().getWorldEditLoaded()){
-			arenaSchematic = SchematicHandler.getSchematicFile("arena");
+			if(GameManager.getGameManager().getConfiguration().getPickRandomArenaFromList() && !GameManager.getGameManager().getConfiguration().getArenaList().isEmpty()) {
+				if (mapName == null) {
+					Random r = new Random();
+					mapName = GameManager.getGameManager().getConfiguration().getArenaList().get(r.nextInt(GameManager.getGameManager().getConfiguration().getArenaList().size()));
+					Bukkit.getLogger().info("selected world " + mapName);
+				}
+				arenaSchematic = SchematicHandler.getSchematicFile(mapName);
+			}
+			else{
+				arenaSchematic = SchematicHandler.getSchematicFile("arena");}
+				
         	if(!arenaSchematic.exists()){
 				enable = false;
-				Bukkit.getLogger().info("[UhcCore] Arena schematic not found in 'plugins/UhcCore/arena.schematic'. There will be a deathmatch at 0 0.");
+				Bukkit.getLogger().info("[UhcCore] Arena schematic not found in 'plugins/UhcCore/*.schematic'. There will be a deathmatch at 0 0.");
         	}
 		}else{
 			Bukkit.getLogger().info("[UhcCore] No WorldEdit installed so ending with deathmatch at 0 0");

--- a/src/main/java/com/gmail/val59000mc/schematics/DeathmatchArena.java
+++ b/src/main/java/com/gmail/val59000mc/schematics/DeathmatchArena.java
@@ -37,23 +37,25 @@ public class DeathmatchArena{
 	}
 	
 	private void checkIfSchematicCanBePasted() {
-		if(GameManager.getGameManager().getConfiguration().getWorldEditLoaded()){
-			if(GameManager.getGameManager().getConfiguration().getPickRandomArenaFromList() && !GameManager.getGameManager().getConfiguration().getArenaList().isEmpty()) {
+		if (GameManager.getGameManager().getConfiguration().getWorldEditLoaded()) {
+			if (GameManager.getGameManager().getConfiguration().getPickRandomArenaFromList()
+					&& !GameManager.getGameManager().getConfiguration().getArenaList().isEmpty()) {
 				if (mapName == null) {
 					Random r = new Random();
 					mapName = GameManager.getGameManager().getConfiguration().getArenaList().get(r.nextInt(GameManager.getGameManager().getConfiguration().getArenaList().size()));
 					Bukkit.getLogger().info("selected world " + mapName);
 				}
 				arenaSchematic = SchematicHandler.getSchematicFile(mapName);
+			} else {
+				arenaSchematic = SchematicHandler.getSchematicFile("arena");
 			}
-			else{
-				arenaSchematic = SchematicHandler.getSchematicFile("arena");}
-				
-        	if(!arenaSchematic.exists()){
+
+			if (!arenaSchematic.exists()) {
 				enable = false;
-				Bukkit.getLogger().info("[UhcCore] Arena schematic not found in 'plugins/UhcCore/*.schematic'. There will be a deathmatch at 0 0.");
-        	}
-		}else{
+				Bukkit.getLogger().info(
+						"[UhcCore] Arena schematic not found in 'plugins/UhcCore/*.schematic'. There will be a deathmatch at 0 0.");
+			}
+		} else {
 			Bukkit.getLogger().info("[UhcCore] No WorldEdit installed so ending with deathmatch at 0 0");
 			enable = false;
 		}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -459,6 +459,15 @@ deathmatch:
     teleport-spots-block: BEDROCK
     # The arena.schematic is pasted at x=10000 z=10000, you can choose here the y coordinate
     paste-at-y: 100
+    
+  #Set it to true to pick a random arena schematic from the list
+  pick-random-arena-from-list: false
+
+  #Write names of arena schematics placed in /plugins/UhcCore .
+  list:
+  - map1
+  - map2
+    
 
   # When no deathmatch arena is installed the deathmatch will be at the center of the map.
   center-deathmatch:


### PR DESCRIPTION
Hey Mezy,

I was looking through the suggestions in the discord and saw that someone wanted the ability to randomly select the schematic for a deathmatch arena. I implemented this by changing the checkIfSchematicCanBePasted() function in the DeathmatchArena class. It checks if the pickRandomArenaFromList boolean is true, then sets the name for the arena schematic to a random name specified by a list in the config file. I've tested it to make sure it works, but more thorough testing is probably required. I've updated the config file to accommodate these changes as well.

Thanks,
Guessedlake72