### PR TITLE
Add config option to drop team inventory on team elimination

### DIFF
--- a/src/main/java/com/gmail/val59000mc/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/gmail/val59000mc/listeners/PlayerDeathListener.java
@@ -10,9 +10,11 @@ import com.gmail.val59000mc.languages.Lang;
 import com.gmail.val59000mc.players.PlayerState;
 import com.gmail.val59000mc.players.PlayersManager;
 import com.gmail.val59000mc.players.UhcPlayer;
+import com.gmail.val59000mc.players.UhcTeam;
 import com.gmail.val59000mc.scenarios.Scenario;
 import com.gmail.val59000mc.scenarios.ScenarioManager;
 import com.gmail.val59000mc.scenarios.scenariolisteners.SilentNightListener;
+import com.gmail.val59000mc.scenarios.scenariolisteners.TeamInventoryListener;
 import com.gmail.val59000mc.threads.TimeBeforeSendBungeeThread;
 import com.gmail.val59000mc.utils.UniversalMaterial;
 import com.gmail.val59000mc.utils.VersionUtils;
@@ -37,6 +39,7 @@ public class PlayerDeathListener implements Listener{
 		Player player = event.getEntity();
 		GameManager gm = GameManager.getGameManager();
 		PlayersManager pm = gm.getPlayersManager();
+		ScenarioManager sm = gm.getScenarioManager();
 		MainConfiguration cfg = gm.getConfiguration();
 		UhcPlayer uhcPlayer = pm.getUhcPlayer(player);
 
@@ -80,12 +83,21 @@ public class PlayerDeathListener implements Listener{
 			}
 		}
 
+		// Drop the team inventory if the last player on a team was killed
+		if (sm.isActivated(Scenario.TEAMINVENTORY))
+		{
+			UhcTeam team = uhcPlayer.getTeam();
+			if (team.getPlayingMembers().size() == 1)
+			{
+				((TeamInventoryListener) sm.getScenarioListener(Scenario.TEAMINVENTORY)).dropTeamInventory(team, player.getLocation());
+			}
+		}
+
 		// Store drops in case player gets re-spawned.
 		uhcPlayer.getStoredItems().clear();
 		uhcPlayer.getStoredItems().addAll(event.getDrops());
 
 		// eliminations
-		ScenarioManager sm = gm.getScenarioManager();
 		if (!sm.isActivated(Scenario.SILENTNIGHT) || !((SilentNightListener) sm.getScenarioListener(Scenario.SILENTNIGHT)).isNightMode()) {
 			gm.broadcastInfoMessage(Lang.PLAYERS_ELIMINATED.replace("%player%", player.getName()));
 		}

--- a/src/main/java/com/gmail/val59000mc/players/PlayersManager.java
+++ b/src/main/java/com/gmail/val59000mc/players/PlayersManager.java
@@ -17,6 +17,7 @@ import com.gmail.val59000mc.languages.Lang;
 import com.gmail.val59000mc.scenarios.Scenario;
 import com.gmail.val59000mc.scenarios.ScenarioManager;
 import com.gmail.val59000mc.scenarios.scenariolisteners.SilentNightListener;
+import com.gmail.val59000mc.scenarios.scenariolisteners.TeamInventoryListener;
 import com.gmail.val59000mc.schematics.DeathmatchArena;
 import com.gmail.val59000mc.threads.CheckRemainingPlayerThread;
 import com.gmail.val59000mc.threads.TeleportPlayersThread;
@@ -867,6 +868,7 @@ public class PlayersManager{
 	public void killOfflineUhcPlayer(UhcPlayer uhcPlayer, @Nullable Location location, Set<ItemStack> playerDrops, @Nullable Player killer){
 		GameManager gm = GameManager.getGameManager();
 		PlayersManager pm = gm.getPlayersManager();
+		ScenarioManager sm = gm.getScenarioManager();
 		MainConfiguration cfg = gm.getConfiguration();
 
 		if (uhcPlayer.getState() != PlayerState.PLAYING){
@@ -906,12 +908,21 @@ public class PlayersManager{
 			}
 		}
 
+		// Drop the team inventory if the last player on a team was killed
+		if (sm.isActivated(Scenario.TEAMINVENTORY))
+		{
+			UhcTeam team = uhcPlayer.getTeam();
+			if (team.getPlayingMembers().size() == 1)
+			{
+				((TeamInventoryListener) sm.getScenarioListener(Scenario.TEAMINVENTORY)).dropTeamInventory(team, location);
+			}
+		}
+
 		// Store drops in case player gets re-spawned.
 		uhcPlayer.getStoredItems().clear();
 		uhcPlayer.getStoredItems().addAll(playerDrops);
 
 		// eliminations
-		ScenarioManager sm = gm.getScenarioManager();
 		if (!sm.isActivated(Scenario.SILENTNIGHT) || !((SilentNightListener) sm.getScenarioListener(Scenario.SILENTNIGHT)).isNightMode()) {
 			gm.broadcastInfoMessage(Lang.PLAYERS_ELIMINATED.replace("%player%", uhcPlayer.getName()));
 		}

--- a/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
@@ -26,7 +26,7 @@ public enum Scenario{
     BESTPVE(UniversalMaterial.REDSTONE, BestPvEListener.class),
     TRIPLEORES(UniversalMaterial.REDSTONE_ORE, TripleOresListener.class),
     DOUBLEORES(UniversalMaterial.REDSTONE_ORE, DoubleOresListener.class),
-    TEAMINVENTORY(UniversalMaterial.CHEST),
+    TEAMINVENTORY(UniversalMaterial.CHEST, TeamInventoryListener.class),
     NOCLEAN(UniversalMaterial.QUARTZ, NoCleanListener.class),
     HASTEYBOYS(UniversalMaterial.DIAMOND_PICKAXE, HasteyBoysListener.class),
     LUCKYLEAVES(UniversalMaterial.OAK_LEAVES, LuckyLeavesListener.class),

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/TeamInventoryListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/TeamInventoryListener.java
@@ -1,0 +1,30 @@
+package com.gmail.val59000mc.scenarios.scenariolisteners;
+
+import com.gmail.val59000mc.players.UhcTeam;
+import com.gmail.val59000mc.scenarios.Option;
+import com.gmail.val59000mc.scenarios.ScenarioListener;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+
+public class TeamInventoryListener extends ScenarioListener{
+
+    @Option(key = "drop-on-team-elimination")
+    private boolean dropOnLastDeath = false;
+
+    public void dropTeamInventory(UhcTeam team, Location location)
+    {
+        if (dropOnLastDeath)
+        {
+            World world = location.getWorld();
+            for (ItemStack stack : team.getTeamInventory().getContents())
+            {
+                if (stack != null)
+                {
+                    world.dropItemNaturally(location, stack);
+                }
+            }
+            team.getTeamInventory().clear();
+        }
+    }
+}

--- a/src/main/resources/scenarios.yml
+++ b/src/main/resources/scenarios.yml
@@ -7,6 +7,9 @@ timebomb:
 bestpve:
   # Time between healing players on best PvE list.
   delay: 600
+teaminventory:
+  # Should the team inventory be dropped when the last player on a team is eliminated?
+  drop-on-team-elimination: false
 noclean:
   # Time players are invulnerable for.
   duration: 30


### PR DESCRIPTION
Normally, when a team is eliminated and the Team Inventory scenario is enabled, the items in the Team Inventory remain in the Team Inventory, and cannot be collected by any other teams. This pull request adds a config option in scenarios.yml (disabled by default) which, when enabled, will cause all the items in a team inventory to be dropped on the ground when the last player on a team dies.
To add this configuration option, I added a ScenarioListener for the TeamInventory scenario. This Listener does not actually listen to any events.