### PR TITLE
fix LoveAtFirstSight team creation

### DIFF
--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/LoveAtFirstSightListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/LoveAtFirstSightListener.java
@@ -54,8 +54,8 @@ public class LoveAtFirstSightListener extends ScenarioListener{
             return; // One of the teams is full so no team can be made
         }
 
-        if (!uhcDamaged.getTeam().isSolo() && !uhcDamager.getTeam().isSolo()){
-            return; // Neither of the players are solo so a team can't be created
+        if (!uhcDamaged.getTeam().isSolo() || !uhcDamager.getTeam().isSolo()){
+            return; // One of the players aren't solo so a team can't be created
         }
 
         if (getTeamManager().getPlayingUhcTeams().size() <= 2){


### PR DESCRIPTION
Currently if the max team size is higher than 2 any solo player gets added to a team, even if one of the people is already duo'd up. This fixes that.