### PR TITLE
Bugfix: Weakest Link scenario not killing players with absorption hearts

### DIFF
--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/WeakestLinkListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/WeakestLinkListener.java
@@ -31,7 +31,7 @@ public class WeakestLinkListener extends ScenarioListener{
         // Kill player
         try {
             Player player = lowest.getPlayer();
-            player.damage(player.getHealth() + player.getAbsorptionAmount());
+            player.damage(100);
         }catch (UhcPlayerNotOnlineException ex){
             ex.printStackTrace();
         }

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/WeakestLinkListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/WeakestLinkListener.java
@@ -31,7 +31,7 @@ public class WeakestLinkListener extends ScenarioListener{
         // Kill player
         try {
             Player player = lowest.getPlayer();
-            player.damage(player.getHealth());
+            player.damage(player.getHealth() + player.getAbsorptionAmount());
         }catch (UhcPlayerNotOnlineException ex){
             ex.printStackTrace();
         }


### PR DESCRIPTION
When the scenario kills a player, it only uses the regular HP, not counting the extra HP from the absorption effect of golden apples. Thus not completely killing the player, since it might only do 16 HP of damage, when the player has 4 HP extra.

So I just did a quick change of adding the absorption HP to the regular HP when damaging the player to fix this issue.
Closes #67 