### PR TITLE
Add check to only drop item if it isn't AIR, removing error message

### DIFF
--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/RandomizedDropsListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/RandomizedDropsListener.java
@@ -87,7 +87,9 @@ public class RandomizedDropsListener extends ScenarioListener{
 		event.setCancelled(true);
 		block.setType(Material.AIR);
 		Location dropLocation = block.getLocation().add(.5, 0, .5);
-		dropLocation.getWorld().dropItemNaturally(dropLocation, blockDrop);
+		if (!blockDrop.getType().equals(Material.AIR)) {
+			dropLocation.getWorld().dropItemNaturally(dropLocation, blockDrop);
+		}
 
 		Player player = event.getPlayer();
 		ItemStack tool = player.getItemInHand();


### PR DESCRIPTION
Fixes #59 