### PR TITLE
Bugfixes (tracking compass, pvp, random drops)

### DIFF
--- a/src/main/java/com/gmail/val59000mc/languages/Lang.java
+++ b/src/main/java/com/gmail/val59000mc/languages/Lang.java
@@ -141,6 +141,7 @@ public class Lang{
 	public static String ITEMS_COMPASS_PLAYING_ERROR;
 	public static String ITEMS_COMPASS_PLAYING_COOLDOWN;
 	public static String ITEMS_COMPASS_PLAYING_POINTING;
+	public static String ITEMS_COMPASS_PLAYING_ERROR_DIMENSION;
 	public static String ITEMS_KIT_SELECTION;
 	public static String ITEMS_KIT_INVENTORY;
 	public static String ITEMS_KIT_SELECTED;
@@ -351,6 +352,7 @@ public class Lang{
 		ITEMS_COMPASS_PLAYING_ERROR = getString(lang, "items.compass-playing-error", "&cThere is no playing teammate to point to.");
 		ITEMS_COMPASS_PLAYING_COOLDOWN = getString(lang, "items.compass-playing-cooldown", "&cYou're clicking the compass too fast, please wait!");
 		ITEMS_COMPASS_PLAYING_POINTING = getString(lang, "items.compass-playing-pointing", "&aPointing towards %player%'s last location (%distance% blocks)");
+		ITEMS_COMPASS_PLAYING_ERROR_DIMENSION = getString(lang, "items.compass-playing-error-dimension", "&cCannot point towards %player%, they are in a different dimension.");
 		ITEMS_KIT_SELECTION = getString(lang, "items.kit-selection", "&aRight click to choose a kit");
 		ITEMS_KIT_INVENTORY = getString(lang, "items.kit-inventory", "&2Kit selection", 32);
 		ITEMS_KIT_SELECTED =  getString(lang, "items.kit-selected", "&aYou selected the kit %kit%");

--- a/src/main/java/com/gmail/val59000mc/listeners/PlayerDamageListener.java
+++ b/src/main/java/com/gmail/val59000mc/listeners/PlayerDamageListener.java
@@ -6,10 +6,7 @@ import com.gmail.val59000mc.languages.Lang;
 import com.gmail.val59000mc.players.PlayerState;
 import com.gmail.val59000mc.players.PlayerManager;
 import com.gmail.val59000mc.players.UhcPlayer;
-import org.bukkit.entity.Arrow;
-import org.bukkit.entity.LightningStrike;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -30,7 +27,8 @@ public class PlayerDamageListener implements Listener{
 	public void onPlayerDamage(EntityDamageByEntityEvent event){
 		handlePvpAndFriendlyFire(event);
 		handleLightningStrike(event);
-		handleArrow(event);
+		// Handle arrows, tridents, and thrown potions
+		handleProjectile(event);
 	}
 
 	@EventHandler(priority=EventPriority.NORMAL)
@@ -92,21 +90,21 @@ public class PlayerDamageListener implements Listener{
 		}
 	}
 	
-	private void handleArrow(EntityDamageByEntityEvent event){
+	private void handleProjectile(EntityDamageByEntityEvent event){
 
 		PlayerManager pm = gameManager.getPlayerManager();
 		
-		if(event.getEntity() instanceof Player && event.getDamager() instanceof Arrow){
-			Projectile arrow = (Projectile) event.getDamager();
+		if(event.getEntity() instanceof Player && (event.getDamager() instanceof Arrow || event.getDamager() instanceof Trident || event.getDamager() instanceof ThrownPotion)){
+			Projectile projectile = (Projectile) event.getDamager();
 			final Player shot = (Player) event.getEntity();
-			if(arrow.getShooter() instanceof Player){
+			if(projectile.getShooter() instanceof Player){
 				
 				if(!gameManager.getPvp()){
 					event.setCancelled(true);
 					return;
 				}
 
-				UhcPlayer uhcDamager = pm.getUhcPlayer((Player) arrow.getShooter());
+				UhcPlayer uhcDamager = pm.getUhcPlayer((Player) projectile.getShooter());
 				UhcPlayer uhcDamaged = pm.getUhcPlayer(shot);
 
 				if(!friendlyFire && uhcDamager.getState().equals(PlayerState.PLAYING) && uhcDamager.isInTeamWith(uhcDamaged)){

--- a/src/main/java/com/gmail/val59000mc/players/UhcPlayer.java
+++ b/src/main/java/com/gmail/val59000mc/players/UhcPlayer.java
@@ -340,16 +340,26 @@ public class UhcPlayer {
 				Player bukkitPlayer = getPlayer();
 				Player bukkitPlayerPointing = compassPlayingCurrentPlayer.getPlayer();
 
-				bukkitPlayer.setCompassTarget(bukkitPlayerPointing.getLocation());
+				// Point towards player if they are in the same dimension
+				if(bukkitPlayer.getWorld() == bukkitPlayerPointing.getWorld()) {
 
-				String message = Lang.ITEMS_COMPASS_PLAYING_POINTING.replace("%player%", compassPlayingCurrentPlayer.getName());
+					bukkitPlayer.setCompassTarget(bukkitPlayerPointing.getLocation());
 
-				if (message.contains("%distance%")){
-					int distance = (int) bukkitPlayer.getLocation().distance(bukkitPlayerPointing.getLocation());
-					message = message.replace("%distance%", String.valueOf(distance));
+					String message = Lang.ITEMS_COMPASS_PLAYING_POINTING.replace("%player%", compassPlayingCurrentPlayer.getName());
+
+					if (message.contains("%distance%")) {
+						int distance = (int) bukkitPlayer.getLocation().distance(bukkitPlayerPointing.getLocation());
+						message = message.replace("%distance%", String.valueOf(distance));
+					}
+
+					sendMessage(message);
 				}
 
-				sendMessage(message);
+				// Otherwise, send error message to player indicating the target player is in another dimension
+				else {
+					sendMessage(Lang.ITEMS_COMPASS_PLAYING_ERROR_DIMENSION.replace("%player%", compassPlayingCurrentPlayer.getName()));
+				}
+
 			} catch (UhcPlayerNotOnlineException e) {
 				sendMessage(Lang.TEAM_MESSAGE_PLAYER_NOT_ONLINE.replace("%player%", compassPlayingCurrentPlayer.getName()));
 			}

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/RandomizedDropsListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/RandomizedDropsListener.java
@@ -87,7 +87,10 @@ public class RandomizedDropsListener extends ScenarioListener{
 		event.setCancelled(true);
 		block.setType(Material.AIR);
 		Location dropLocation = block.getLocation().add(.5, 0, .5);
-		dropLocation.getWorld().dropItemNaturally(dropLocation, blockDrop);
+		// Only drop item if it is not air to prevent errors
+		if (!blockDrop.getType().equals(Material.AIR)) {
+			dropLocation.getWorld().dropItemNaturally(dropLocation, blockDrop);
+		}
 
 		Player player = event.getPlayer();
 		ItemStack tool = player.getItemInHand();


### PR DESCRIPTION
- Added warning message sent to player when trying to track player in other world with compass
- Fixed players being able to inflict damage on other players using tridents and splash potions before pvp time starts 
- Fixed players being able to inflict damage on other players using lingering potions before pvp time starts and on teammates even if friendly fire is disabled
- Fixed error in console when randomized drops scenario caused air to be dropped