### PR TITLE
Add option for enchantments levels in Hastey Boys

### DIFF
--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/HasteyBoysListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/HasteyBoysListener.java
@@ -1,5 +1,6 @@
 package com.gmail.val59000mc.scenarios.scenariolisteners;
 
+import com.gmail.val59000mc.scenarios.Option;
 import com.gmail.val59000mc.customitems.CraftsManager;
 import com.gmail.val59000mc.scenarios.ScenarioListener;
 import org.bukkit.enchantments.Enchantment;
@@ -8,6 +9,12 @@ import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.inventory.ItemStack;
 
 public class HasteyBoysListener extends ScenarioListener{
+
+    @Option(key = "efficiency")
+    private int efficiency = 3;
+    
+    @Option(key = "durability")
+    private int durability = 1;
 
     @EventHandler
     public void onPlayerCraft(CraftItemEvent e){
@@ -19,8 +26,8 @@ public class HasteyBoysListener extends ScenarioListener{
         }
 
         try {
-            item.addEnchantment(Enchantment.DIG_SPEED,3);
-            item.addEnchantment(Enchantment.DURABILITY,1);
+            item.addEnchantment(Enchantment.DIG_SPEED,efficiency);
+            item.addEnchantment(Enchantment.DURABILITY,durability);
         }catch (IllegalArgumentException ex){
             // Nothing
         }

--- a/src/main/resources/scenarios.yml
+++ b/src/main/resources/scenarios.yml
@@ -34,3 +34,8 @@ achievementhunter:
   health-at-start: 10
   # Amount of health added per achievement.
   health-added: 1
+hastey_boys:
+  # Level of Efficiency enchantment.
+  efficiency: 3
+  # Level of Durability enchantment.
+  durability: 1


### PR DESCRIPTION
Resolves #36.

- [x] Add option for enchantments levels in Hastey Boys to `HasteyBoysListener.java`.
- [x] Add option for enchantments levels in Hastey Boys to `scenarios.yml`.