### PR TITLE
fixed typo

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -445,7 +445,7 @@ border:
 deathmatch:
   # Set it to false to make an endless game until one team wins
   enable: true
-  # The time in seconds before the deathmatch stats
+  # The time in seconds before the deathmatch starts
   delay: 3600
   # Set it to true if you want players in deathmatch to be in adventure mode. (false = survival mode)
   deathmatch-adventure-mode: false


### PR DESCRIPTION
fixed minor typo : 

# The time in seconds before the deathmatch **stats** > # The time in seconds before the deathmatch **starts**