### PR TITLE
Typo in Schematic.java

### DIFF
--- a/src/main/java/com/gmail/val59000mc/schematics/Schematic.java
+++ b/src/main/java/com/gmail/val59000mc/schematics/Schematic.java
@@ -126,7 +126,7 @@ public class Schematic {
     }
 
     public int getWidth() {
-        Validate.isTrue(height != -1, "Can't be obtained before pasting schematic");
+        Validate.isTrue(width != -1, "Can't be obtained before pasting schematic");
         return width;
     }
 


### PR DESCRIPTION
Replaces `height` with `width` (probably copy-pasted). I randomly noticed this while reading the code.