### PR TITLE
Changed WorldEdit repo because it was moved

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
         }
         maven {
             // WorldEdit
-            url = 'http://maven.sk89q.com/repo/'
+            url = 'https://maven.enginehub.org/repo/'
         }
         maven {
             // ProtocolLib


### PR DESCRIPTION
Fixes `Could not find com.sk89q.worldedit:worldedit-core:6.1.4-SNAPSHOT.` on gradlew build